### PR TITLE
changing merge type to avoid losing entries

### DIFF
--- a/gd_coronavirus_abwassermonitoring/make_dataset.py
+++ b/gd_coronavirus_abwassermonitoring/make_dataset.py
@@ -25,7 +25,7 @@ def main():
     df_abwasser = make_dataframe_abwasserdaten()
     df_all = df_abwasser.merge(df_bl, how='outer')
     df_bs = make_dataframe_bs()
-    df_all = df_all.merge(df_bs, how='right')
+    df_all = df_all.merge(df_bs, how='left')
     df_all = calculate_columns(df_all)
     # change date format for json file
     df_all['Datum'] = df_all['Datum'].dt.strftime('%Y-%m-%d')


### PR DESCRIPTION
This was tested by running both versions (old version with right merge and new version with left merge) and then comparing the csv-files that were created. They create the same files, but new version does not lose entries, since there are more Abwasser-measurings than Corona-Fallzahlen